### PR TITLE
all any command to run on all the devices in an enterprise.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 Sample Codes demonstrating use of Esper API's
 
 - This python script allows all the individual device commands to be
-  fire on the group.
-- This will fetch all the active devices in a group and initiate the
+  fire on the specific group or all the device under enterprise.
+- This will fetch all the active devices in a group or enterprise and initiate the
   command on the same.
 
 Please edit the python file to update your Enterprise Related information
@@ -20,11 +20,15 @@ ENTERPRISE_ID = '<ENTERPRISE-ID>'
 - Usage:
   esper_group_actions [-h]
    -c {uninstall, whitelist, brightness, alarm_volume, ring_volume, music_volume, notification_volume, bluetooth, wifi, gps, ping, reboot}
-   -g GROUP_ID
+   -g GROUP_ID (or "all" for all the devices in a all the groups)
    -v VALUE
    
 - Example:
   ./esper_group_actions -g 52ecfb3c-d1ad-4e66-8cf9-85daff8d7f3c -c ring_volume -v 50
   ./esper_group_actions -g 52ecfb3c-d1ad-4e66-8cf9-85daff8d7f3c -c ping
   ./esper_group_actions -g 52ecfb3c-d1ad-4e66-8cf9-85daff8d7f3c -c reboot
+  ./esper_group_actions -g all -c reboot
+  ./esper_group_actions -g all -c ping
+
+
   

--- a/esper_group_actions.py
+++ b/esper_group_actions.py
@@ -41,9 +41,9 @@ CONFIGURATION.api_key_prefix['Authorization'] = 'Bearer'
 ENTERPRISE_ID = '<ENTERPRISE-ID>'
 
 # int | Number of results to return per page. (optional) (default to 20)
-CONFIGURATION.group_per_page_limit = 5000
+CONFIGURATION.per_page_limit = 5000
 # int | The initial index from which to return the results.(optional) default to 0)
-CONFIGURATION.group_per_page_offset = 0
+CONFIGURATION.per_page_offset = 0
 
 ###############################
 
@@ -243,8 +243,8 @@ def get_devices_in_group(group_id):
     api_instance = esperclient.DeviceApi(esperclient.ApiClient(CONFIGURATION))
     try:
         api_response = api_instance.get_all_devices(ENTERPRISE_ID, group=group_id,
-                                                    limit=CONFIGURATION.group_per_page_limit,
-                                                    offset=CONFIGURATION.group_per_page_offset)
+                                                    limit=CONFIGURATION.per_page_limit,
+                                                    offset=CONFIGURATION.per_page_offset)
         if len(api_response.results):
             for device in api_response.results:
                 if device.status == 1:  # Check for active devices only
@@ -258,10 +258,11 @@ def get_all_devices_in_enterprise():
     # create an instance of the API class
     api_instance = esperclient.DeviceGroupApi(esperclient.ApiClient(CONFIGURATION))
     try:
-        api_response = api_instance.get_all_groups(ENTERPRISE_ID)
+        api_response = api_instance.get_all_groups(ENTERPRISE_ID,
+                                                    limit=CONFIGURATION.per_page_limit,
+                                                    offset=CONFIGURATION.per_page_offset)
         if len(api_response.results):
             for group in api_response.results:
-                #print(group.id)
                 # add all the devices in this group to global list of devices
                 get_devices_in_group(group.id)
 


### PR DESCRIPTION
- commands can be executed on all the devices in an enterprise using
following:
- instead or group id, if you say as "all", command will get executed on
all the devices irrespective of a group

  ./esper_group_actions -g all -c reboot